### PR TITLE
Web manifest and LocationSelector

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -15,5 +15,6 @@
     ],
     "theme_color": "#108885",
     "background_color": "#ffffff",
-    "display": "standalone"
+    "display": "standalone",
+    "start_url": "/"
 }

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
-    "name": "",
-    "short_name": "",
+    "name": "Corona Frontend",
+    "short_name": "Corona",
     "icons": [
         {
             "src": "/android-chrome-192x192.png",
@@ -13,7 +13,7 @@
             "type": "image/png"
         }
     ],
-    "theme_color": "#ffffff",
+    "theme_color": "#108885",
     "background_color": "#ffffff",
     "display": "standalone"
 }

--- a/src/components/LocationSelector.vue
+++ b/src/components/LocationSelector.vue
@@ -4,8 +4,8 @@
       <label class="block tracking-wide text-gray-700 text-s font-bold mb-2" for="select-country">
         I am from...
       </label>
-      <div>
-        <button class="bg-gray-200 text-left font-bold py-2 px-4 rounded w-full md:w-1/2 flex" @click="showOptions" v-on-clickaway="closeOptions">
+      <div class="relative">
+        <button class="bg-gray-200 text-left font-bold py-2 px-4 rounded w-full md:w-1/2 flex" @click="toggleOptions" v-on-clickaway="closeOptions">
           <div v-if="currentCountry && currentCountry.code === 'global'">
             <i class="fas fa-globe"></i>
             {{currentCountry.name}}
@@ -22,17 +22,17 @@
           </div>
         </button>
 
-        <ul class="absolute text-gray-700 pt-1 z-50" v-if="optionsShowed">
+        <ul class="absolute text-gray-700 pt-1 z-50 w-full md:w-1/2" v-if="optionsShowed">
           <li>
             <a class="bg-gray-200 hover:bg-gray-400 py-2 px-4 block whitespace-no-wrap" @click="selectCountry(global)">
               <i class="fas fa-globe"></i>
-              Global
+              <span class="ml-2">Global</span>
             </a>
           </li>
           <li v-for="country in countries" v-bind:key="country.code">
             <a class="bg-gray-200 hover:bg-gray-400 py-2 px-4 block whitespace-no-wrap" @click="selectCountry(country)">
               <span :class="'flag-icon flag-icon-'+country.code"></span>
-              {{country.name}}
+              <span class="ml-2">{{country.name}}</span>
             </a>
           </li>
         </ul>
@@ -123,6 +123,9 @@ export default {
     },
     closeOptions(){
       this.optionsShowed = false;
+    },
+    toggleOptions() {
+      this.optionsShowed = !this.optionsShowed;
     },
     loadStats() {
       const selectedCountry = !this.currentCountry || this.currentCountry.code === 'global' ? '' : this.currentCountry.name;


### PR DESCRIPTION
## Bug Fixes:
- Web manifest is not valid
- LocationSelector behavior is not intuitive

### Web Manifest
Web Manifest is incorrect, as you can verified in DevTools Application Tab.
![image](https://user-images.githubusercontent.com/24528512/73390879-f1e45700-4311-11ea-91fd-3d53ce65d87b.png)

Notes:
- `short_name` should be less than 12 characters in total, as [recommended by Google](https://developers.google.com/web/tools/lighthouse/audits/manifest-contains-short_name).
- I use the "primary-500" color for the `theme_color`

### LocationSelector
LocationSelector is designed like a select, so user would expect it behaves like a select where clicking it again would close it. Please see the comparisons of before and after below.

Notes:
- I've tweak the style of the list to make it align with the select box.

Current behavior in https://www.coronatracker.com:
![locationSelector-current](https://user-images.githubusercontent.com/24528512/73392917-afbd1480-4315-11ea-8920-1addea56c377.gif)

Fixed behavior:
![locationSelector-new](https://user-images.githubusercontent.com/24528512/73392961-c2cfe480-4315-11ea-9474-c5c2a17a1510.gif)
