### PR TITLE
Update TopStats.vue

### DIFF
--- a/components/TopStats.vue
+++ b/components/TopStats.vue
@@ -26,7 +26,6 @@
       </tbody>
     </table>
     <div class="my-2 font-bold text-xs text-gray-600 leading-tight">
-      * Cases identified on a cruise ship currently in Japanese territorial waters.
       <a name="notes-on-others" class="anchor"></a>
     </div>
   </div>


### PR DESCRIPTION
Removed the asterisk description as it is not being used in the main page.
As "Others" isn't being included in the affected countries, the asterisk section at the bottom of affected countries can be removed.
As seen in the highlighted section below:
![image](https://user-images.githubusercontent.com/46293489/74707025-909a0e80-5253-11ea-886d-806acd69e80c.png)
