### PR TITLE
fix: causes cdc url

### DIFF
--- a/pages/causes.vue
+++ b/pages/causes.vue
@@ -4,7 +4,7 @@
       <h1 class="text-2xl font-bold mb-4">What is COVID-19?</h1>
 
       <iframe style="width:100%;height:500px;" src="https://www.youtube.com/embed/OZcRD9fV7jo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-      <iframe style="width:100%;height:100%" src="https://www.cdc.gov/coronavirus/COVID-19/about/transmission.html"></iframe>
+      <iframe style="width:100%;height:100%" src="https://www.cdc.gov/coronavirus/2019-ncov/about/index.html"></iframe>
     </div>
   </main>
 </template>


### PR DESCRIPTION
Change CDC source in causes page to [this](https://www.cdc.gov/coronavirus/2019-ncov/about/index.html).