### PR TITLE
new: bar chart component

### DIFF
--- a/api/stats.js
+++ b/api/stats.js
@@ -21,5 +21,11 @@ export default axios => ({
   getDailyCasesByCountry: (countryCode) => {
     return axios.get(`/v3/stats/bno/daily_cases/country?countryCode=${countryCode}`)
     .then(res => res.data);
+  },
+
+  getTrendByCountry: (countryCode, startDate, endDate) => {
+    return axios.get(`/analytics/trend/country?country_code=${countryCode}&start_date=${startDate}&end_date=${endDate}`)
+    .then(res => res.data);
   }
+
 });

--- a/components/Country/BarChartNumber.vue
+++ b/components/Country/BarChartNumber.vue
@@ -1,0 +1,93 @@
+<template>
+  <div class="flex-1 relative overflow-hidden">
+    <div class="border border-gray-400 p-4 rounded relative barchart-box">
+      <div class="relative">
+        <div class="text-gray-900 font-bold text-xl">{{ title }}</div>
+        <div class="text-gray-900 font-bold text-xs mb-2">({{ startDate }} - {{ endDate }})</div>
+        
+      </div>
+      <div class="z-0 chart-wrapper">
+        <client-only placeholder="Loading...">
+          <apexcharts
+            :options="chartOptions"
+            :series="trendData"
+            :height="height"
+          ></apexcharts>
+        </client-only>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  components: {},
+  mounted() {},
+  props: {
+    height: {
+      type: Number,
+      default: 360
+    },
+    trendData: {
+      type: Array,
+      default: []
+    },
+    trendDates: {
+      type: Array,
+      default: []
+    },
+    title: {
+      type: String,
+      default: "Past 30 Days Chart"
+    },
+  },
+  data: function() {
+    return {
+      startDate: this.trendDates[0].slice(0,10),
+      endDate: this.trendDates[this.trendDates.length-1].slice(0,10),
+      chartOptions: {
+        chart: {
+          type: "bar",
+          zoom: {
+            enabled: false
+          },
+          toolbar: {
+            show: false
+          },
+          stacked: true,
+        },
+        dataLabels: {
+          enabled: false
+        },
+        yaxis: {
+          show: true
+        },
+        xaxis: {
+          type: 'datetime',
+          categories: this.trendDates,
+          show: true
+        },
+        legend: {
+          position: 'left',
+          offsetX: -20,
+          offsetY: 125
+        },
+      }
+    };
+  }
+};
+</script>
+
+<style scoped>
+.chart-wrapper {
+  position: absolute;
+  bottom: 0;
+  padding: 10;
+  width: 95%;
+  opacity: 0.4;
+  overflow: hidden;
+}
+.barchart-box {
+  height: 360px;
+}
+</style>

--- a/pages/country/_country.vue
+++ b/pages/country/_country.vue
@@ -56,8 +56,16 @@
       </div>
       <div class="flex flex-wrap">
         <div class="w-full md:w-3/4 p-2">
-          <TrendingNews :country="country" />
+            <bar-chart-number
+              :height="360"
+              :trendData="countryTrend.trendData"
+              :trendDates="countryTrend.trendDates"
+              :title="$t('Past 30 Days Chart')"
+              style="margin-bottom: 12px;"
+            />
+            <TrendingNews :country="country" />
         </div>
+
         <div class="w-full md:w-1/4 p-2">
           <client-only>
             <TwitterFeed twitter-handle="WHO" :data-height="1750"/>
@@ -71,6 +79,7 @@
 <script>
 import FatalityRate from '../../components/Analytics/FatalityRate'
 import LineChartNumber from '~/components/Country/LineChartNumber'
+import BarChartNumber from '~/components/Country/BarChartNumber'
 import Overview from '~/components/Country/Overview'
 import PositiveRate from '../../components/Analytics/PositiveRate'
 import TwitterFeed from '~/components/TwitterFeed'
@@ -83,6 +92,7 @@ export default {
     GrowthRate,
     FatalityRate,
     LineChartNumber,
+    BarChartNumber,
     Overview,
     PositiveRate,
     TwitterFeed,
@@ -124,15 +134,17 @@ export default {
         totalCount: 0,
         inICUCount: 0
       },
-
       activeCases: {
         totalCount: 0,
         percentage: 0
       },
-
       recoveredCases: {
         totalCount: 0,
         percentage: 0
+      },
+      countryTrend: {
+        trendData: [],
+        trendDates: []
       }
     }
   },
@@ -156,10 +168,16 @@ export default {
     async loadInformation(countryCode) {
       let totalCases;
       let dailyCases;
+      let countryTrendRaw;
 
       try {
         totalCases = await this.$api.stats.getTotalCasesByCountry(countryCode)
         dailyCases = await this.$api.stats.getDailyCasesByCountry(countryCode)
+        countryTrendRaw = await this.$api.stats.getTrendByCountry(
+          countryCode,
+          new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
+          new Date().toISOString().slice(0, 10)
+        );
       }
       catch (err) {
         this.pageState = this.PAGE_STATES.HAS_ERROR
@@ -186,9 +204,11 @@ export default {
       const FRL = 100 - FRU
       const PRL = 100 - PRU
 
+      // Fatality Rate
       this.fatalityRate.days = 10
       this.fatalityRate.data = [Number(FRL), Number(FRU)]
 
+      // Positive Rate
       this.positiveRate.days = 10
       this.positiveRate.data = [Number(PRL), Number(PRU)]
 
@@ -205,6 +225,28 @@ export default {
       this.recoveredCases.totalCount = dailyCases.diffDailyRecovered
       this.recoveredCases.percentage =
         ((dailyCases.diffDailyRecovered / totalCases.recovered) * 100).toFixed(1)
+
+      // Country Trend
+      let countryTrendConfirmed = []
+      let countryTrendRecovered = []
+      let countryTrendDeath = []
+      countryTrendRaw.forEach(country => {
+        countryTrendConfirmed.push(country["confirmed"])
+        countryTrendRecovered.push(country["recovered"])
+        countryTrendDeath.push(country["dead"])
+
+        this.countryTrend.trendDates.push(country["date_posted"])
+      });
+      this.countryTrend.trendData = [{
+        "name": "confirmed",
+        "data": countryTrendConfirmed
+      },{
+        "name": "recovered",
+        "data": countryTrendRecovered
+      },{
+        "name": "death",
+        "data": countryTrendDeath
+      }]
     },
   }
 }


### PR DESCRIPTION
- added bar chart component
- rely on new API to search for "trend" data of a country between 2 dates (currently it takes today's date and 30 days before today) [PR here](https://github.com/theleadio/corona-web/pull/20)

- CN
![image](https://user-images.githubusercontent.com/23413788/77020686-d07f0f00-6941-11ea-97f3-5ab086db06b1.png)

- MY
![image](https://user-images.githubusercontent.com/23413788/77020696-db39a400-6941-11ea-83dc-92f7f18fc798.png)
