### PR TITLE
Fix: Responsive adjustments

### DIFF
--- a/components/Analytics/AffectedCountry.vue
+++ b/components/Analytics/AffectedCountry.vue
@@ -45,26 +45,7 @@
       </client-only>
     </div>
 
-    <div class="mt-3" style="max-height: 36.3rem; overflow: auto;">
-      <!--<table class="table-fixed w-full border">
-        <thead class="text-xs text-center font-bold leading-tight">
-          <tr>
-            <td class="border">Country</td>
-            <td class="border">Total Confirmed</td>
-            <td class="border">Total Recovered</td>
-            <td class="border">Total Deaths</td>
-          </tr>
-        </thead>
-
-        <tbody class="text-xs text-center leading-tight">
-          <tr v-for="loc in countries" :key="loc.country">
-            <td class="border px-1 py-2">{{ loc.country }}</td>
-            <td class="border px-1 py-2">{{ parseInt(loc.total_confirmed).toLocaleString() }}</td>
-            <td class="border px-1 py-2">{{ parseInt(loc.total_recovered).toLocaleString() }}</td>
-            <td class="border px-1 py-2">{{ parseInt(loc.total_dead).toLocaleString() }}</td>
-          </tr>
-        </tbody>
-      </table>-->
+    <div class="mt-3 hidden lg:block" style="max-height: 36.3rem; overflow: auto;">
 
       <table class="table-auto w-full">
         <thead class="text-xs leading-tight border-b-2">

--- a/components/Country/Overview.vue
+++ b/components/Country/Overview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="max-w-full rounded border border-gray-400 bg-white p-3">
+  <div class="max-w-full rounded border border-gray-400 bg-white p-3 h-full">
     <p class="text-xl font-bold pl-2">
       <Flag :country-code="country.code"></Flag>
       {{country.name}} {{ $t('Overview') }}

--- a/pages/analytics/index.vue
+++ b/pages/analytics/index.vue
@@ -2,7 +2,7 @@
   <div class="flex flex-wrap">
     <SidebarNav></SidebarNav>
 
-    <div class="w-full lg:w-5/6 px-5 pt-2 bg-gray-200">
+    <div class="w-full lg:w-5/6 px-2 pt-2 bg-gray-200">
       <div class="pl-2">
         <p class="text-2xl font-bold">COVID-19 {{ $t('Overview') }}</p>
 
@@ -14,20 +14,20 @@
       <div class="flex flex-wrap">
         <div class="w-full lg:w-1/2 px-2">
           <div class="max-w-full rounded shadow-md bg-white p-3 mb-5">
-            <div class="flex flex-col lg:flex-row">
-              <div class="px-3">
+            <div class="flex flex-row lg:flex-row">
+              <div class="px-2">
                 <p class="text-sm font-bold text-red-600">{{ $t('Total Confirmed') }}</p>
-                <p class="text-2xl font-bold text-red-600">{{ confirmed | formatNumber }}</p>
+                <p class="text-xl font-bold text-red-600">{{ confirmed | formatNumber }}</p>
               </div>
 
-              <div class="px-3">
+              <div class="px-2">
                 <p class="text-sm font-bold text-green-600">{{ $t('Total Recovered') }}</p>
-                <p class="text-2xl font-bold text-green-600">{{ recovered | formatNumber }}</p>
+                <p class="text-xl font-bold text-green-600">{{ recovered | formatNumber }}</p>
               </div>
 
-              <div class="px-3">
+              <div class="px-2">
                 <p class="text-sm font-bold text-gray-600">{{ $t('Total Deaths') }}</p>
-                <p class="text-2xl font-bold text-gray-600">{{ deaths | formatNumber }}</p>
+                <p class="text-xl font-bold text-gray-600">{{ deaths | formatNumber }}</p>
               </div>
             </div>
           </div>

--- a/pages/analytics/index.vue
+++ b/pages/analytics/index.vue
@@ -15,19 +15,53 @@
         <div class="w-full lg:w-1/2 px-2">
           <div class="max-w-full rounded shadow-md bg-white p-3 mb-5">
             <div class="flex flex-col lg:flex-row">
-              <div class="px-5">
+              <div class="px-3">
                 <p class="text-sm font-bold text-red-600">{{ $t('Total Confirmed') }}</p>
-                <p class="text-4xl font-bold text-red-600">{{ confirmed | formatNumber }}</p>
+                <p class="text-2xl font-bold text-red-600">{{ confirmed | formatNumber }}</p>
               </div>
 
-              <div class="px-5">
+              <div class="px-3">
                 <p class="text-sm font-bold text-green-600">{{ $t('Total Recovered') }}</p>
-                <p class="text-4xl font-bold text-green-600">{{ recovered | formatNumber }}</p>
+                <p class="text-2xl font-bold text-green-600">{{ recovered | formatNumber }}</p>
               </div>
 
-              <div class="px-5">
+              <div class="px-3">
                 <p class="text-sm font-bold text-gray-600">{{ $t('Total Deaths') }}</p>
-                <p class="text-4xl font-bold text-gray-600">{{ deaths | formatNumber }}</p>
+                <p class="text-2xl font-bold text-gray-600">{{ deaths | formatNumber }}</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="w-full rounded shadow-md bg-white p-3 mb-5 block lg:hidden">
+            <div class="mt-3" style="max-height: 36.3rem; overflow: auto;">
+              <table class="table-auto w-full">
+                <thead class="text-xs leading-tight border-b-2">
+                <tr>
+                  <th class="border px-2 py-2">{{ $t('Country') }}</th>
+                  <th class="border px-1 py-2">{{ $t('Total Confirmed') }}</th>
+                  <th class="border px-1 py-2">{{ $t('Total Recovered') }}</th>
+                  <th class="border px-1 py-2">{{ $t('Total Deaths') }}</th>
+                </tr>
+                </thead>
+                <tbody class="font-bold">
+                <tr v-for="loc in affectedCountries" :key="loc.countryName">
+                  <td class="bg-gray-200 text-xs border px-2 py-2 hover:bg-primary hover:text-white">
+                    <span v-if="loc.countryName === 'Others'">{{loc.countryName}}</span>
+                    <nuxt-link :to="`/country/${loc.countryCode.toLowerCase()}`" style="display:block" v-else>
+                      <Flag :country-code="loc.countryCode"></Flag>
+                      {{loc.countryName}}
+                    </nuxt-link>
+                    <a v-if="loc.countryName === 'Others'" href="#notes-on-others">*</a>
+                  </td>
+                  <td class="text-center border px-1 py-2">{{ loc.confirmed | formatNumber }}</td>
+                  <td class="text-center border px-1 py-2">{{ loc.recovered | formatNumber }}</td>
+                  <td class="text-center border px-1 py-2">{{ loc.deaths | formatNumber }}</td>
+                </tr>
+                </tbody>
+              </table>
+              <div class="my-2 font-bold text-xs text-gray-600 leading-tight">
+                * {{ $t('Cases identified on a cruise ship currently in Japanese territorial waters.') }}
+                <a name="notes-on-others" class="anchor"></a>
               </div>
             </div>
           </div>
@@ -56,10 +90,11 @@ import SidebarNav from '~/components/Analytics/SidebarNav'
 import OutbreakTrendChart from '~/components/Analytics/OutbreakTrend'
 import AffectedRegion from '~/components/Analytics/AffectedRegion'
 import AffectedCountry from '~/components/Analytics/AffectedCountry'
+import Flag from '~/components/Flag';
 
 export default {
-  components: { SidebarNav, OutbreakTrendChart, AffectedRegion, AffectedCountry },
-  
+  components: { SidebarNav, OutbreakTrendChart, AffectedRegion, AffectedCountry, Flag },
+
   mounted () {
     this.loadStats()
     this.loadOutbreakTrend()
@@ -81,6 +116,12 @@ export default {
 
   metaInfo: {
     title: 'Analytics',
+  },
+
+  computed: {
+    affectedCountries() {
+      return this.affectedCountryData.filter(i => i.confirmed)
+    }
   },
 
   methods: {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -4,13 +4,21 @@
 
 			<div class="w-full md:w-2/3 px-2">
 				<LocationSelector v-model="country" />
-								
+				<div class="w-full block md:hidden mt-4 mb-8">
+					<TopStats />
+					<div
+						class="mt-2 text-center underline text-blue-500 font-semibold"
+					>
+						<nuxt-link :to="localePath('analytics')">{{ $t('Full list here') }}</nuxt-link>
+					</div>
+				</div>
+
 				<Search class="mt-4 mb-8" />
 				<TrendingNews :country="country" />
 			</div>
 
 			<div class="w-full md:w-1/3 px-2">
-				<div class="">
+				<div class="hidden md:block">
 					<TopStats />
 					<div
 						class="mt-2 text-center underline text-blue-500 font-semibold"
@@ -72,7 +80,7 @@
 	import BuyMeACoffee from '~/components/BuyMeACoffee';
 
 
-	
+
 
 	export default {
 		metaInfo: {
@@ -88,7 +96,7 @@
 			LearnPrevention,
 			HealthcareInstitutions,
 			BuyMeACoffee,
-			
+
 		},
 		mounted() {},
 		data: function() {


### PR DESCRIPTION
- Fix: Panel alignment issue
- On mobile, show country stats after total stats on home page.
- Show countries table after global stats in responsive mode on Analytics page
- Update AffectedCountry component to accomodate this change.
- Fix: Responsive adjustment for overview info on analytics page
