### PR TITLE
Fix: Tooltip stats not displaying information on maps.

### DIFF
--- a/components/Analytics/AffectedCountry.vue
+++ b/components/Analytics/AffectedCountry.vue
@@ -25,19 +25,19 @@
             color="red">
             <l-popup>
               <p class="text-xs">
-                <span class="font-bold">{{ $t('Country') }}:</span> {{ loc.countryName }}
+                <span class="font-bold">{{ $t('Country') }}:</span> {{ loc.country }}
               </p>
 
               <p class="text-xs">
-                <span class="font-bold">{{ $t('Total Confirmed') }}:</span> {{ loc.confirmed | formatNumber }}
+                <span class="font-bold">{{ $t('Total Confirmed') }}:</span> {{ loc.totalConfirmed | formatNumber }}
               </p>
 
               <p class="text-xs">
-                <span class="font-bold">{{ $t('Total Recovered') }}:</span> {{ loc.recovered | formatNumber }}
+                <span class="font-bold">{{ $t('Total Recovered') }}:</span> {{ loc.totalRecovered | formatNumber }}
               </p>
 
               <p class="text-xs">
-                <span class="font-bold">{{ $t('Total Deaths') }}:</span> {{ loc.deaths | formatNumber }}
+                <span class="font-bold">{{ $t('Total Deaths') }}:</span> {{ loc.totalDeaths | formatNumber }}
               </p>
             </l-popup>
           </l-circle-marker>


### PR DESCRIPTION
Map tooltip's on Analytics page is not displaying the data, after the api endpoint update. 