### PR TITLE
Adding sorting capabilities to TopStats component

### DIFF
--- a/api/stats.js
+++ b/api/stats.js
@@ -1,7 +1,9 @@
 export default axios => ({
-  getTopNCountryStats: (limit) => {
+  getTopNCountryStats: (limit, orderBy, isDescending) => {
     const params = {
       limit,
+      orderBy,
+      isDescending
     };
 
     return axios.get(`/v3/stats/worldometer/topCountry`, { params })

--- a/assets/css/coronatracker.css
+++ b/assets/css/coronatracker.css
@@ -11,3 +11,27 @@
 main.container {
   padding-top: 2rem;
 }
+
+.sorter-header {
+  cursor: pointer;
+  border: solid black;
+  border-width: 0 2px 2px 0;
+  display: inline-block;
+  padding: 2px;
+  margin-left: 4px;
+}
+
+.up-arrow {
+  transform: rotate(-135deg);
+  -webkit-transform: rotate(-135deg);
+}
+
+.down-arrow {
+  transform: rotate(45deg);
+  -webkit-transform: rotate(45deg);
+  margin-bottom: 2px;
+}
+
+.pointer {
+  cursor: pointer;
+}

--- a/components/TopStats.vue
+++ b/components/TopStats.vue
@@ -9,9 +9,15 @@
       <thead class="text-xs leading-tight border-b-2">
       <tr>
         <th class="border px-2 py-2">{{ $t('country') }}</th>
-        <th class="border px-1 py-2">{{ $t('confirmed') }}</th>
-        <th class="border px-1 py-2">{{ $t('recovered') }}</th>
-        <th class="border px-1 py-2">{{ $t('deaths') }}</th>
+        <th class="border px-1 py-2 pointer" @click="headerClick('confirmed')">
+          {{ $t('confirmed') }}<span v-if="sortField === 'confirmed'" v-bind:class="{'up-arrow': !sortInDescendingOrder, 'down-arrow': sortInDescendingOrder }" class="sorter-header"></span>
+        </th>
+        <th class="border px-1 py-2 pointer" @click="headerClick('recovered')">
+          {{ $t('recovered') }}<span v-if="sortField === 'recovered'" v-bind:class="{'up-arrow': !sortInDescendingOrder, 'down-arrow': sortInDescendingOrder }" class="sorter-header"></span>
+        </th>
+        <th class="border px-1 py-2 pointer" @click="headerClick('deaths')">
+          {{ $t('deaths') }}<span v-if="sortField === 'deaths'" v-bind:class="{'up-arrow': !sortInDescendingOrder, 'down-arrow': sortInDescendingOrder }" class="sorter-header"></span>
+      </th>
       </tr>
       </thead>
       <tbody class="font-bold">
@@ -91,6 +97,17 @@
         type: Boolean,
         default: false,
       },
+      sortField: {
+        type: String,
+        default: "confirmed"
+      },
+      sortInDescendingOrder: {
+        type: Boolean,
+        default: true
+      },
+      headerClick: {
+        type: Function
+      }
     },
     data() {
       return {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -34,6 +34,9 @@
           <TopStats
             :is-loading="isLoadingCountryStats"
             :country-stats="countryStats"
+            :sort-field="sortField"
+            :sort-in-descending-order="sortInDescendingOrder"
+            :header-click="resortCountryStats"
           />
           <div
             class="mt-2 text-center underline text-blue-500 font-semibold"
@@ -135,7 +138,9 @@
           mobileImage: surveyImageMobile,
           link: "https://tinyurl.com/CoronaTrackerSurvey",
           expiresOn: "2020-04-01"
-        }
+        },
+        sortField: "confirmed",
+        sortInDescendingOrder: true
       };
     },
     methods: {
@@ -190,13 +195,24 @@
         this.isLoadingCountryStats = true;
         try {
           const limit = 15;
-          this.countryStats = await this.$api.stats.getTopNCountryStats(limit);
+          this.countryStats = await this.$api.stats.getTopNCountryStats(limit, this.sortField, this.sortInDescendingOrder);
         } catch (ex) {
           console.log('[fetchCountryStats] Error:', ex);
         } finally {
           this.isLoadingCountryStats = false;
         }
       },
+      async resortCountryStats(sortField) {
+        if (this.sortField === sortField) {
+          this.sortInDescendingOrder = !this.sortInDescendingOrder;
+        }
+        else {
+          this.sortField = sortField;
+          this.sortInDescendingOrder = true;
+        }
+
+        this.fetchCountryStats();
+      }
     },
     watch: {
       country(newVal, oldVal) {


### PR DESCRIPTION
This allows the user to sort stats by number of confirmed, recovered, and deaths in ascending or descending order. This is dependent of theleadio/corona-web#66.

![image](https://user-images.githubusercontent.com/11719477/78517778-c0b25800-7794-11ea-9d64-7744fa6bcf5c.png)

![image](https://user-images.githubusercontent.com/11719477/78517804-cb6ced00-7794-11ea-8dfd-0ad7639fac67.png)
